### PR TITLE
Gracefully handle hashref for total hits

### DIFF
--- a/lib/CPAN/Perl/Releases/MetaCPAN.pm
+++ b/lib/CPAN/Perl/Releases/MetaCPAN.pm
@@ -55,7 +55,7 @@ sub get {
             die "$res->{status} $res->{reason}, $uri$message\n";
         }
         my $hash = $self->{json}->decode($res->{content});
-        $total = $hash->{hits}{total} unless defined $total;
+        $total = ref $hash->{hits}{total} ? $hash->{hits}{total}{value} : $hash->{hits}{total} unless defined $total;
         push @release, map { $_->{fields} } @{$hash->{hits}{hits}};
         last if $total <= @release;
         $from = @release;


### PR DESCRIPTION
In recent versions of Elasticsearch, `total` is returned as a hashref with a `value` key by default (and may not be exact). MetaCPAN may work around this to provide the old API (https://github.com/metacpan/metacpan-api/pull/1394), but gracefully handle it just in case we get the new default format.